### PR TITLE
type hinting changed

### DIFF
--- a/src/pride.py
+++ b/src/pride.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import sys
 import random
 from dataclasses import dataclass
-
-from typing import List
 
 from argparse import ArgumentParser
 
@@ -183,7 +183,7 @@ def draw(pride_flag: PrideFlag) -> None:
     return drawing_routine
 
 
-def draw_all(pride_flags: List[PrideFlag]) -> None:
+def draw_all(pride_flags: list[PrideFlag]) -> None:
     def drawing_routine(window: curses.window):
         running = True
         while running:

--- a/src/pride.py
+++ b/src/pride.py
@@ -3,6 +3,8 @@ import sys
 import random
 from dataclasses import dataclass
 
+from typing import List
+
 from argparse import ArgumentParser
 
 import curses
@@ -181,7 +183,7 @@ def draw(pride_flag: PrideFlag) -> None:
     return drawing_routine
 
 
-def draw_all(pride_flags: list[PrideFlag]) -> None:
+def draw_all(pride_flags: List[PrideFlag]) -> None:
     def drawing_routine(window: curses.window):
         running = True
         while running:


### PR DESCRIPTION
When trying to run it I was getting this error

```
$ pride -c
Traceback (most recent call last):
  File "/usr/local/bin/pride", line 184, in <module>
    def draw_all(pride_flags: list[PrideFlag]) -> None:
TypeError: 'type' object is not subscriptable
```

changing the hint on that line to the `List` class from the typing library seems to have fixed this error for me.